### PR TITLE
Fix easyCompile to work under Gentoo.

### DIFF
--- a/easyCompile
+++ b/easyCompile
@@ -26,7 +26,7 @@
 
 PRO_FILE="Taffy.pro"
 
-QMAKE=$(which qmake)
+[ -z "${QMAKE}" ] && QMAKE=$(which qmake)
 QMAKE_ARGS="-r -spec linux-g++-64"
 QMAKE_ARGS_DEBUG="CONFIG+=debug"
 


### PR DESCRIPTION
When multiple Qt versions are installed, QMAKE can be exported in the
system's environment.

Signed-off-by: Olaf Lessenich xai@linux.com
