### PR TITLE
Add config for travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+dist: trusty
+
+language: cpp
+
+addons:
+    apt:
+        packages:
+            - qt5-default
+            - qttools5-dev-tools
+
+script: ./easyCompile


### PR DESCRIPTION
I chose to use ubuntu 14.04 because we need qt5.

Signed-off-by: Olaf Lessenich xai@linux.com
